### PR TITLE
downloaded buffer initialize when download failed

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -63,11 +63,13 @@ std::string image_downloader(const std::string &url) {
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
 
         res = curl_easy_perform(curl);
+        curl_easy_cleanup(curl);
+
         if(res != CURLE_OK){
             LOG("curl_easy_perform() failed: " + std::string(curl_easy_strerror(res)));
+            readBuffer = "";
         }
-            
-        curl_easy_cleanup(curl);
+    
         
         LOG("Downloading... Done");
     }


### PR DESCRIPTION
다운로드 실패 시 string 값을 빈 값으로 변경하여 length에 상관없이 이미지를 변경하지 않도록 함.