### PR TITLE
Fix illegal call to `curl_easy_cleanup()`

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -100,7 +100,6 @@ std::string download_curl(const std::string &url, struct curl_slist *header){
         LOG("Curl is not initialized");
     }
 
-    curl_easy_cleanup(curl);
     return "-1";
 }
 


### PR DESCRIPTION
In most cases, the http request will succeed and there is no problem.

but if `curl_easy_perform()` fails, `curl_easy_cleanup()` is called twice on line 89 and line 103, which leads to undefined behavior.

this commit solves this problem.